### PR TITLE
chore: removing the update of npm and using 22 as publishing node version

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -18,10 +18,8 @@ jobs:
       - uses: actions/checkout@v6.0.2
       - uses: actions/setup-node@v6.4.0
         with:
-          node-version: 20
+          node-version: 22
           registry-url: https://registry.npmjs.org/
-      - name: Update npm
-        run: npm install --ignore-scripts -g npm@latest
       - run: npm -v
       - run: npm ci --ignore-scripts
       - run: npm run compile


### PR DESCRIPTION
# Please check before merging

- [x] Is the content of the `README.md` file still up-to-date?
- [ ] ~Have you added an entry to the `CHANGELOG.md`?~
- [x] Is the pull request title written in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format?
- [ ] ~VSCode: Did you follow the [UX Guidelines](https://code.visualstudio.com/api/ux-guidelines/overview)?~

# Description

No longer updating npm before publishing. Also using the node v22 as node 20 is no longer supported and node 22 is still in maintenance.

This resolves https://github.com/aditosoftware/vscode-logging/security/code-scanning/5.

