### PR TITLE
chore: use only currently supported node versions in pipelines

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [22.x, 24.x, 26.x]
         os: [macos-latest, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -18,8 +18,7 @@ jobs:
       - uses: actions/checkout@v7.0.0
       - uses: actions/setup-node@v6.4.0
         with:
-          node-version: 22
-          registry-url: https://registry.npmjs.org/
+          node-version: 22.x
       - run: npm -v
       - run: npm ci --ignore-scripts
       - run: npm run compile


### PR DESCRIPTION
# Please check before merging

- [x] Is the content of the `README.md` file still up-to-date?
- [ ] ~Have you added an entry to the `CHANGELOG.md`?~
- [x] Is the pull request title written in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format?
- [ ] ~VSCode: Did you follow the [UX Guidelines](https://code.visualstudio.com/api/ux-guidelines/overview)?~

# Description

Updated the used node.js versions in the pipeline to only use versions that are currently supported. See https://nodejs.org/en/about/previous-releases for details.