### PR TITLE
ci: used fail-fast for better information which pipline fails and swapping to stable version of VS Code, because macOS pipeline works there and not with insiders

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   build:
     strategy:
+       # let other jobs finish as well, maybe they can finish and there is only an error in one of the jobs
+      fail-fast: false
       matrix:
         node-version: [22.x, 24.x, 26.x]
         os: [macos-latest, ubuntu-latest, windows-latest]

--- a/.vscode-test.mjs
+++ b/.vscode-test.mjs
@@ -2,7 +2,7 @@ import { defineConfig } from "@vscode/test-cli";
 
 export default defineConfig({
   files: "out/test/**/*.test.js",
-  version: "insiders",
+  version: "stable",
   mocha: {
     retries: 5,
     parallel: false,


### PR DESCRIPTION
# Please check before merging

- [x] Is the content of the `README.md` file still up-to-date?
- [ ] ~Have you added an entry to the `CHANGELOG.md`?~
- [x] Is the pull request title written in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format?
- [ ] ~VSCode: Did you follow the [UX Guidelines](https://code.visualstudio.com/api/ux-guidelines/overview)?~

# Description

swapped to stable version of VS Code for tests, because insiders build currently produces the following error

```log
✔ Downloaded VS Code (07b4ff1883f94da91f6d698744fc7c3638b59720) into /Users/runner/work/vscode-logging/vscode-logging/.vscode-test/vscode-darwin-arm64-insiders
Test error: Error: spawn /Users/runner/work/vscode-logging/vscode-logging/.vscode-test/vscode-darwin-arm64-insiders/Visual Studio Code - Insiders.app/Contents/MacOS/Electron ENOENT
```

see https://github.com/microsoft/vscode-test/issues/355

also disabled `fast-fail` to see exactly which jobs fail
